### PR TITLE
Fixes usage with serverless-webpack and serverless-offline hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const packagePath = 'node_modules/serverless-offline-direct-lambda';
-const handlerPath = `proxy.js`;
+const handlerPath = 'proxy.js';
 
 class ServerlessPlugin {
   constructor(serverless, options) {
@@ -9,31 +9,37 @@ class ServerlessPlugin {
     this.options = options;
 
     this.hooks = {
-      "before:offline:start:init": this.startHandler.bind(this),
+      'before:offline:start': this.startHandler.bind(this),
     };
   }
 
   startHandler() {
+    let location = '';
+    try {
+      location = this.serverless.service.custom['serverless-offline'].location;
+      this.serverless.service.custom['serverless-offline'].location = '';
+    } catch (_) { }
+
     this.serverless.cli.log('Running Serverless Offline with direct lambda support');
 
-    addProxies(this.serverless.service.functions);
+    addProxies(this.serverless.service.functions, location);
   }
 }
 
-const addProxies = functionsObject => {
+const addProxies = (functionsObject, location) => {
   Object.keys(functionsObject).forEach(fn => {
 
     // filter out functions with event config,
     // leaving just those intended for direct lambda-to-lambda invocation
     const functionObject = functionsObject[fn];
-    if (!functionObject.events || functionObject.events.length == 0) {
-      const pf = functionProxy(functionObject);
+    if (!functionObject.events || !functionObject.events.some((event) => event === 'http')) {
+      const pf = functionProxy(functionObject, location);
       functionsObject[pf.name] = pf;
     }
   });
 };
 
-const functionProxy = functionBeingProxied => ({
+const functionProxy = (functionBeingProxied, location) => ({
   name: `${functionBeingProxied.name}_proxy`,
   handler: `${packagePath}/proxy.handler`,
   events: [
@@ -46,8 +52,9 @@ const functionProxy = functionBeingProxied => ({
           template: {
             'application/json': JSON.stringify(
               {
+                location,
+                body: "$input.json('$')",
                 targetHandler :  functionBeingProxied.handler,
-                body: "$input.json('$')"
               }
             )
           }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ const addProxies = (functionsObject, location) => {
     // filter out functions with event config,
     // leaving just those intended for direct lambda-to-lambda invocation
     const functionObject = functionsObject[fn];
-    if (!functionObject.events || !functionObject.events.some((event) => event === 'http')) {
+    if (!functionObject.events ||
+        !functionObject.events.some((event) => Object.keys(event)[0] === 'http')) {
       const pf = functionProxy(functionObject, location);
       functionsObject[pf.name] = pf;
     }

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const addProxies = (functionsObject, location) => {
 const functionProxy = (functionBeingProxied, location) => ({
   name: `${functionBeingProxied.name}_proxy`,
   handler: `${packagePath}/proxy.handler`,
+  environment: functionBeingProxied.environment,
   events: [
     {
       http: {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,11 @@ class ServerlessPlugin {
     this.serverless = serverless;
     this.options = options;
 
+    const boundStartHandler = this.startHandler.bind(this);
+
     this.hooks = {
-      'before:offline:start': this.startHandler.bind(this),
+      'before:offline:start': boundStartHandler,
+      'before:offline:start:init': boundStartHandler,
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,15 @@ class ServerlessPlugin {
   }
 
   startHandler() {
+    // Serverless Webpack overrides the location to its output directory. Set
+    // location to that directory.
     let location = '';
     try {
       location = this.serverless.service.custom['serverless-offline'].location;
       this.serverless.service.custom['serverless-offline'].location = '';
     } catch (_) { }
+
+    location = `${this.serverless.config.servicePath}/${location}`;
 
     this.serverless.cli.log('Running Serverless Offline with direct lambda support');
 

--- a/proxy.js
+++ b/proxy.js
@@ -12,8 +12,11 @@ async function handler(event, context) {
   const targetEvent = JSON.parse(Payload);
   const targetContext = {
     ...context,
-    clientContext: JSON.parse(Buffer.from(ClientContext, 'base64')),
   };
+
+  if (ClientContext) {
+    targetContext.clientContext = JSON.parse(Buffer.from(ClientContext, 'base64'));
+  }
 
   const funcResult = new Promise((resolve, reject) => {
     const result = target[targetHandlerFunction](targetEvent, targetContext, (error, response) => {

--- a/proxy.js
+++ b/proxy.js
@@ -1,24 +1,25 @@
 const serializeError = require('serialize-error');
+const path = require('path');
 
-function handler(event, context, callback) {
+async function handler(event, context, callback) {
   // extract the path to the handler (relative to the project root)
   // and the function to call on the handler
-  const [targetHandlerFile, targetHandlerFunction] = event.targetHandler.split(".");
-  const target = require('../../' + targetHandlerFile);
+  const [targetHandlerFile, targetHandlerFunction] = event.targetHandler.split('.');
+  const target = require(path.resolve(__dirname, '../..', event.location, targetHandlerFile));
 
   // call the target function
-  target[targetHandlerFunction](event.body, context, (error, response) => {
+  return target[targetHandlerFunction](event.body, context, (error, response) => {
     if (error) {
       callback(null, {
         StatusCode: 500,
         FunctionError: 'Handled',
-        Payload: serializeError(error)
-      })
+        Payload: serializeError(error),
+      });
     } else {
       callback(null, {
         StatusCode: 200,
-        Payload: JSON.stringify(response)
-      })
+        Payload: JSON.stringify(response),
+      });
     }
   });
 }

--- a/proxy.js
+++ b/proxy.js
@@ -1,7 +1,7 @@
 const serializeError = require('serialize-error');
 const path = require('path');
 
-export async function handler(event, context) {
+async function handler(event, context) {
   const { ClientContext, FunctionName, InvocationType, LogType, Payload } = event.body;
 
   // extract the path to the handler (relative to the project root)
@@ -35,3 +35,5 @@ export async function handler(event, context) {
     return { StatusCode: 500, FunctionError: 'Handled', Payload: serializeError(error) };
   }
 }
+
+module.exports.handler = handler;

--- a/proxy.js
+++ b/proxy.js
@@ -2,13 +2,21 @@ const serializeError = require('serialize-error');
 const path = require('path');
 
 async function handler(event, context, callback) {
+  const { ClientContext, FunctionName, InvocationType, LogType, Payload } = event.body;
+
   // extract the path to the handler (relative to the project root)
   // and the function to call on the handler
   const [targetHandlerFile, targetHandlerFunction] = event.targetHandler.split('.');
   const target = require(path.resolve(__dirname, '../..', event.location, targetHandlerFile));
 
+  const targetEvent = JSON.parse(Payload);
+  const targetContext = {
+    ...context,
+    clientContext: JSON.parse(Buffer.from(ClientContext, 'base64')),
+  };
+
   // call the target function
-  return target[targetHandlerFunction](event.body, context, (error, response) => {
+  return target[targetHandlerFunction](targetEvent, targetContext, (error, response) => {
     if (error) {
       callback(null, {
         StatusCode: 500,


### PR DESCRIPTION
To start off, to my knowledge, the previous hook `offline:start:init` does not work directly with a `before` handle.  

Secondly, a function handler location can be customized by the use of `serverless.custom.serverless-offline.location`. https://github.com/serverless-heaven/serverless-webpack/ utilizes this to reference bundles in `.webpack/service` for example.

Lastly, `http` events are now checked explicitly, rather than relying on no events at all.